### PR TITLE
fix: broken unit tests for broken AppProvider in frontend-platform

### DIFF
--- a/src/setupTest.jsx
+++ b/src/setupTest.jsx
@@ -66,3 +66,8 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
 }));
 
 jest.setTimeout(1000000);
+
+jest.mock('@edx/frontend-platform/react/hooks', () => ({
+  ...jest.requireActual('@edx/frontend-platform/react/hooks'),
+  useParagonTheme: () => [{ isThemeLoaded: true }, jest.fn()],
+}));


### PR DESCRIPTION
### Description

This PR applies a partial testing solution to the problem some MFEs have with unit testing. The problem comes from the `AppProvider.jsx` of frontend-platform, specifically in the edunext flavored version, after applying the necessary [backports](https://github.com/openedx/frontend-platform/pull/689) to provide compatibility with Varsify. 

For more information, https://openedx.atlassian.net/wiki/spaces/BPL/pages/3770744958/Migrating+MFEs+to+Paragon+design+tokens+and+CSS+variables#Requirements:

#### How Has This Been Tested?

Unit tests no longer fail.