### PR TITLE
fix: fixed border not showing when user clicks on an option post

### DIFF
--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -67,7 +67,7 @@ const DiscussionPostType = ({
           'border-primary': selected,
           'border-light-400': !selected,
         })}
-        style={{ cursor: 'pointer', width: `${enableInContextSidebar ? '10.021rem' : '14.25rem'}` }}
+        style={{ cursor: 'pointer', width: `${enableInContextSidebar ? '10.021rem' : '14.25rem'}`, border: '2px solid' }}
       >
         <Card.Section className="px-4 py-3 d-flex flex-column align-items-center">
           <span className="text-primary-300 mb-0.5">{icon}</span>


### PR DESCRIPTION
### Description

This PR adds the border property directly into the PostEditor component so the user can see the option being selected when adding a post in the discussions tab.

### How to test

1. Go to the Discussion MFE and click on the button "Add post"
2. You should see the borders displaying correctly on the Discussion card and the Question card.
3. Select any of these options and you should see the border selected correctly
4. 
![imagen](https://github.com/user-attachments/assets/25c3667d-03e1-433e-932a-c228b5381c9a)


